### PR TITLE
LTSVIEWER-293 Add support for v3 manifests

### DIFF
--- a/demo/demoEntry.js
+++ b/demo/demoEntry.js
@@ -6,8 +6,8 @@ document.addEventListener("DOMContentLoaded", () => {
     id: "mirador",
     windows: [
       {
-        manifestId: "https://iiif.lib.harvard.edu/manifests/ids:10274486",
-      },
+        manifestId: ""
+      }
     ]
   };
 

--- a/demo/demoEntry.js
+++ b/demo/demoEntry.js
@@ -6,7 +6,10 @@ document.addEventListener("DOMContentLoaded", () => {
     id: "mirador",
     windows: [
       {
-        manifestId: ""
+        manifestId: "https://nrs.harvard.edu/URN-3:DOAK.RESLIB:40977022:MANIFEST:2"
+      },
+      {
+        manifestId: "https://nrs.harvard.edu/URN-3:DOAK.RESLIB:40977022:MANIFEST:3"
       }
     ]
   };

--- a/src/hideViewerNavigationPlugin.js
+++ b/src/hideViewerNavigationPlugin.js
@@ -32,8 +32,7 @@ class hideViewerNavigation extends Component {
   }
 
   componentDidUpdate() {
-    const isIndividualImage = this.isIndividualImage()
-    if (isIndividualImage) {
+    if (this.isIndividualImage()) {
       window.document.querySelectorAll('.mirador-osd-info').forEach((elem) => elem.remove());
       window.document.querySelectorAll('.mirador-osd-navigation').forEach((elem) => elem.remove());
       window.document.querySelectorAll('[class*="Connect(WithPlugins(ZoomControls))-divider-"]').forEach((elem) => elem.remove());

--- a/src/hideViewerNavigationPlugin.js
+++ b/src/hideViewerNavigationPlugin.js
@@ -3,16 +3,25 @@ import { getManifestoInstance } from 'mirador/dist/es/src/state/selectors/manife
 
 class hideViewerNavigation extends Component {
 
-  viewingHint() {
+  isIndividualImage() {
     const { manifest } = this.props;
-    if (!(
+    const individualValue = 'individuals';
+
+    // IIIF v2
+    if (
       manifest
       && manifest.getSequences()
       && manifest.getSequences()[0]
       && manifest.getSequences()[0].getProperty('viewingHint')
-    )) return [''];
+    ) return manifest.getSequences()[0].getProperty('viewingHint') == individualValue
 
-    return manifest.getSequences()[0].getProperty('viewingHint');
+    // IIIF v3
+    if (
+      manifest
+      && manifest.getBehavior()
+    ) return manifest.getBehavior() == individualValue
+
+    return false;
   }
 
   render() {
@@ -23,9 +32,8 @@ class hideViewerNavigation extends Component {
   }
 
   componentDidUpdate() {
-    let viewingHint = this.viewingHint();
-
-    if (viewingHint == 'individuals') {
+    const isIndividualImage = this.isIndividualImage()
+    if (isIndividualImage) {
       window.document.querySelectorAll('.mirador-osd-info').forEach((elem) => elem.remove());
       window.document.querySelectorAll('.mirador-osd-navigation').forEach((elem) => elem.remove());
       window.document.querySelectorAll('[class*="Connect(WithPlugins(ZoomControls))-divider-"]').forEach((elem) => elem.remove());

--- a/src/hideViewerNavigationPlugin.js
+++ b/src/hideViewerNavigationPlugin.js
@@ -32,7 +32,9 @@ class hideViewerNavigation extends Component {
   }
 
   componentDidUpdate() {
-    if (this.isIndividualImage()) {
+    let isIndividualImage = this.isIndividualImage();
+
+    if (isIndividualImage) {
       window.document.querySelectorAll('.mirador-osd-info').forEach((elem) => elem.remove());
       window.document.querySelectorAll('.mirador-osd-navigation').forEach((elem) => elem.remove());
       window.document.querySelectorAll('[class*="Connect(WithPlugins(ZoomControls))-divider-"]').forEach((elem) => elem.remove());


### PR DESCRIPTION
**JIRA Ticket**: [LTSVIEWER-293](https://at-harvard.atlassian.net/browse/LTSVIEWER-293)

# How should this be tested?
1. Checkout `LTSVIEWER-293-add-v3-support` branch.
1. Add a version 3 manifest (from prod) for a single image to `demo/demoEntry.js`
1. Run `npm install` to install all the node packages.
1. Run `npm run serve` to run the Mirador demo pages with the plugin.
1. Confirm that the navigation does not show up

Repeat the above steps with the following and confirm the correct behavior:
- version 2 manifest (from prod) for a single image (navigation should be hidden)
- version 2 manifest (from prod) for multiple images (navigation should be visible)
- version 3 manifest (from prod) for multiple images (navigation should be visible)

[LTSVIEWER-293]: https://at-harvard-sandbox-502.atlassian.net/browse/LTSVIEWER-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ