### PR TITLE
LTSVIEWER-382 Clean Up HTML

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -18,6 +18,5 @@
   </head>
   <body>
     <div id="mirador"></div>
-    </script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@harvard-lts/mirador-hide-nav-plugin",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@harvard-lts/mirador-hide-nav-plugin",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "react-component"
   ],
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "mirador-analytics-plugin React component",
   "module": "dist/es/index.js",
   "files": [


### PR DESCRIPTION
**LTSVIEWER-382 Clean Up HTML**

---

**JIRA Ticket**: [LTSVIEWER-382](https://at-harvard.atlassian.net/browse/LTSVIEWER-382)

# What does this Pull Request do?
- Clean up extraneous `</script>` tag

# How should this be tested?
- check out `LTSVIEWER-382-html-cleanup` locally
- run `npm i`
- run `npm run serve` and confirm that examples in `demo/demoEntry.js` are displayed as expected

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? no
- integration tests? no


[LTSVIEWER-382]: https://at-harvard.atlassian.net/browse/LTSVIEWER-382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ