### PR TITLE
LTSMPS-454: Self-hosted test coverage badge

### DIFF
--- a/.github/workflows/coverage-node.yml
+++ b/.github/workflows/coverage-node.yml
@@ -1,6 +1,7 @@
 name: Node Unit Tests
 
 on:
+  # Don't trigger this on changes to the badge destination branch
   push:
     branches-ignore:
       - badges/test-coverage
@@ -10,6 +11,59 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-and-publish-dev-qa:
-    uses: harvard-lts/ga-reusable-workflows/.github/workflows/TestCoverageNode.yml@main
-    secrets: inherit
+  test-and-badge:
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed so the default GITHUB_TOKEN can push the badge branch.
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage
+        # Emits coverage/coverage-summary.json (see scripts/coverage-ci.mjs)
+        run: npm run test:unit
+
+      - name: Generate coverage badge
+        run: node scripts/make-coverage-badge.mjs
+
+      - name: Upload coverage badge artifact
+        # Runs on every branch so the badge can be previewed from the run summary
+        # without publishing to the badges/test-coverage branch.
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-badge
+          path: |
+            coverage.svg
+            coverage/coverage-summary.json
+          if-no-files-found: error
+
+      - name: Publish coverage badge
+        # Only publish from pushes to the default branch — PRs (including from
+        # forks) run the tests but never push the badge branch.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          BADGE_BRANCH: badges/test-coverage
+        run: |
+          set -e
+          cp coverage.svg "${RUNNER_TEMP}/coverage.svg"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Create/reset an orphan branch containing only the badge.
+          git checkout --orphan "${BADGE_BRANCH}"
+          git rm -rf . >/dev/null 2>&1 || true
+          cp "${RUNNER_TEMP}/coverage.svg" coverage.svg
+          git add coverage.svg
+          if git diff --cached --quiet; then
+            echo "Coverage badge unchanged; nothing to publish."
+          else
+            git commit -m "Update coverage badge [skip ci]"
+            git push -f origin "${BADGE_BRANCH}"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ es
 node_modules
 npm-debug.log*
 coverage
+coverage.svg
 
 .idea/
 .DS_Store

--- a/scripts/make-coverage-badge.mjs
+++ b/scripts/make-coverage-badge.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Generates a self-hosted coverage badge (coverage.svg) with no third-party
+ * service. Reads line coverage from coverage/coverage-summary.json (produced by
+ * `npm run test:unit`) and writes a shields-style SVG to the repo root.
+ *
+ * The CI workflow (.github/workflows/coverage-node.yml) commits coverage.svg to
+ * the `badges/test-coverage` branch, which the README references via the raw URL.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const SUMMARY_PATH = 'coverage/coverage-summary.json';
+const OUTPUT_PATH = 'coverage.svg';
+
+/** Pick a badge color by coverage percentage (mirrors shields.io defaults). */
+function colorFor(pct) {
+  if (pct >= 90) return '#4c1'; // brightgreen
+  if (pct >= 80) return '#97ca00'; // green
+  if (pct >= 70) return '#a4a61d'; // yellowgreen
+  if (pct >= 60) return '#dfb317'; // yellow
+  if (pct >= 50) return '#fe7d37'; // orange
+  return '#e05d44'; // red
+}
+
+let summary;
+try {
+  summary = JSON.parse(readFileSync(SUMMARY_PATH, 'utf8'));
+} catch (err) {
+  console.error(`Could not read ${SUMMARY_PATH}: ${err.message}`);
+  console.error('Run `npm run test:unit` first to generate the coverage summary.');
+  process.exit(1);
+}
+
+const pct = summary?.total?.lines?.pct;
+if (typeof pct !== 'number') {
+  console.error(`No total.lines.pct found in ${SUMMARY_PATH}`);
+  process.exit(1);
+}
+
+const label = 'coverage';
+const value = `${pct}%`;
+const color = colorFor(pct);
+
+// Approximate text widths (px) at font-size 11 — good enough for a static badge.
+const labelWidth = 6 * label.length + 10;
+const valueWidth = 6 * value.length + 10;
+const totalWidth = labelWidth + valueWidth;
+const labelMid = (labelWidth / 2) * 10;
+const valueMid = (labelWidth + valueWidth / 2) * 10;
+
+const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${totalWidth}" height="20" role="img" aria-label="${label}: ${value}">
+  <title>${label}: ${value}</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="${totalWidth}" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="${labelWidth}" height="20" fill="#555"/>
+    <rect x="${labelWidth}" width="${valueWidth}" height="20" fill="${color}"/>
+    <rect width="${totalWidth}" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+    <text aria-hidden="true" x="${labelMid}" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="${(labelWidth - 10) * 10}">${label}</text>
+    <text x="${labelMid}" y="140" transform="scale(.1)" fill="#fff" textLength="${(labelWidth - 10) * 10}">${label}</text>
+    <text aria-hidden="true" x="${valueMid}" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="${(valueWidth - 10) * 10}">${value}</text>
+    <text x="${valueMid}" y="140" transform="scale(.1)" fill="#fff" textLength="${(valueWidth - 10) * 10}">${value}</text>
+  </g>
+</svg>
+`;
+
+writeFileSync(OUTPUT_PATH, svg);
+console.log(`Wrote ${OUTPUT_PATH} (${label} ${value}, color ${color})`);


### PR DESCRIPTION
**JIRA Ticket**: [LTSMPS-454](https://at-harvard.atlassian.net/browse/LTSVIEWER-454)

# What does this Pull Request do?

Replaces the reusable third-party coverage workflow with a self-hosted coverage badge that requires no external service. The `coverage-node.yml` workflow now runs the unit test suite with coverage, then generates a shields-style `coverage.svg` via a new `scripts/make-coverage-badge.mjs` script that reads line coverage from `coverage/coverage-summary.json`.

Key changes:
- **`scripts/make-coverage-badge.mjs`** (new) — reads `total.lines.pct` from the coverage summary and writes a shields-style SVG, picking a badge color by coverage percentage.
- **`.github/workflows/coverage-node.yml`** — new `test-and-badge` job that installs deps, runs `npm run test:unit`, generates the badge, and uploads it as a `coverage-badge` artifact on every run. On pushes to `main` only, it publishes the badge to an orphan `badges/test-coverage` branch that the README references via raw URL.
- **`.gitignore`** — ignores the generated `coverage.svg`.

# How should this be tested?

1. Go to https://github.com/harvard-lts/mirador-hide-nav-plugin/actions/workflows/coverage-node.yml
2. Click the **Run workflow** button at the top right and select the `LTSMPS-453-self-hosted-coverage-badge` branch.
3. After the run completes successfully, open the run summary and download the generated **coverage-badge** artifact to confirm the `coverage.svg` renders correctly.
4. Note: the badge is only published to the `badges/test-coverage` branch on pushes to `main`, so it will appear in the README once this PR is merged.

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? No — this is CI/tooling only.
- integration tests? No — validated by running the workflow and inspecting the artifact.

# Interested parties

@f8f8ff 

[LTSMPS-454]: https://at-harvard.atlassian.net/browse/LTSMPS-454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ